### PR TITLE
Adjust registration priority for del and ins patterns

### DIFF
--- a/markdown_del_ins.py
+++ b/markdown_del_ins.py
@@ -5,10 +5,10 @@ from markdown.inlinepatterns import SimpleTagInlineProcessor
 class DelInsExtension(Extension):
     def extendMarkdown(self, md):
         del_proc = SimpleTagInlineProcessor(r'(\~\~)(.+?)(\~\~)', 'del')
-        md.inlinePatterns.register(del_proc, 'del', 200)
+        md.inlinePatterns.register(del_proc, 'del', 175)
 
         ins_proc = SimpleTagInlineProcessor(r'(\+\+)(.+?)(\+\+)', 'ins')
-        md.inlinePatterns.register(ins_proc, 'ins', 200)
+        md.inlinePatterns.register(ins_proc, 'ins', 175)
 
 
 def makeExtension(**kwargs):


### PR DESCRIPTION
Current priority is too high and patterns in inline code (between backticks) are processed.